### PR TITLE
Integrate Firebase placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Login App
 
 This Flutter project has been reset with a simple login screen following the Model-View-Intent pattern.
+
+## Firebase setup
+
+1. Add your `google-services.json` file to `android/app/` and `GoogleService-Info.plist` to `ios/Runner/`.
+2. Run `flutterfire configure` to generate `lib/firebase_options.dart` with your Firebase credentials.
+3. The app initializes Firebase on startup using the generated options.

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -1,0 +1,8 @@
+{
+  "project_info": {
+    "project_id": "YOUR_PROJECT_ID",
+    "storage_bucket": "YOUR_PROJECT_ID.appspot.com",
+    "project_number": "1234567890"
+  },
+  "client": []
+}

--- a/ios/Runner/GoogleService-Info.plist
+++ b/ios/Runner/GoogleService-Info.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>PROJECT_ID</key>
+    <string>YOUR_PROJECT_ID</string>
+    <!-- Add the rest of your Firebase config here -->
+</dict>
+</plist>

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,0 +1,11 @@
+import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
+
+/// This file is a placeholder generated for Firebase configuration.
+/// Run `flutterfire configure` to generate the actual values.
+class DefaultFirebaseOptions {
+  static FirebaseOptions get currentPlatform {
+    throw UnsupportedError(
+      'Missing firebase_options.dart. Run `flutterfire configure` to generate it.',
+    );
+  }
+}

--- a/lib/login/firebase_auth_service.dart
+++ b/lib/login/firebase_auth_service.dart
@@ -1,11 +1,23 @@
-import 'dart:async';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 
 import 'auth_service.dart';
 
 class FirebaseAuthService implements AuthService {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+  final GoogleSignIn _googleSignIn = GoogleSignIn();
+
   @override
   Future<void> signInWithGoogle() async {
-    // TODO: integrate Firebase authentication
-    return Future.delayed(const Duration(seconds: 1));
+    final user = await _googleSignIn.signIn();
+    if (user == null) {
+      throw Exception('Sign in aborted');
+    }
+    final auth = await user.authentication;
+    final credential = GoogleAuthProvider.credential(
+      accessToken: auth.accessToken,
+      idToken: auth.idToken,
+    );
+    await _auth.signInWithCredential(credential);
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'firebase_options.dart';
 import 'login/login_view.dart';
 import 'login/firebase_auth_service.dart';
 import 'login/login_intent.dart';
 import 'login/auth_service.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
   final authService = FirebaseAuthService();
   runApp(MyApp(authService: authService));
 }


### PR DESCRIPTION
## Summary
- include Firebase placeholders and configuration steps
- initialize Firebase in `main.dart`
- implement Google sign-in using `firebase_auth`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497d718b00832eb0c13c8338f86761