### PR TITLE
Add logger setup and authentication logs

### DIFF
--- a/lib/login/firebase_auth_service.dart
+++ b/lib/login/firebase_auth_service.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 
+import '../main.dart';
 import 'auth_service.dart';
 
 class FirebaseAuthService implements AuthService {
@@ -9,15 +10,21 @@ class FirebaseAuthService implements AuthService {
 
   @override
   Future<void> signInWithGoogle() async {
-    final user = await _googleSignIn.signIn();
-    if (user == null) {
-      throw Exception('Sign in aborted');
+    try {
+      final user = await _googleSignIn.signIn();
+      if (user == null) {
+        throw Exception('Sign in aborted');
+      }
+      final auth = await user.authentication;
+      final credential = GoogleAuthProvider.credential(
+        accessToken: auth.accessToken,
+        idToken: auth.idToken,
+      );
+      await _auth.signInWithCredential(credential);
+      logger.i('AUTH -> firebase sign in success');
+    } catch (e, st) {
+      logger.e('AUTH -> firebase sign in error: $e', e, st);
+      rethrow;
     }
-    final auth = await user.authentication;
-    final credential = GoogleAuthProvider.credential(
-      accessToken: auth.accessToken,
-      idToken: auth.idToken,
-    );
-    await _auth.signInWithCredential(credential);
   }
 }

--- a/lib/login/login_intent.dart
+++ b/lib/login/login_intent.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import '../main.dart';
 import 'auth_service.dart';
 import 'login_state.dart';
 
@@ -10,15 +11,21 @@ class LoginIntent {
   Stream<LoginState> get state => _controller.stream;
 
   LoginIntent(this._authService) {
+    logger.i('AUTH -> state: initial');
     _controller.add(const LoginState.initial());
   }
 
   Future<void> signInWithGoogle() async {
+    logger.i('AUTH -> state: loading');
     _controller.add(const LoginState.loading());
     try {
+      logger.i('AUTH -> signInWithGoogle called');
       await _authService.signInWithGoogle();
+      logger.i('AUTH -> state: success');
       _controller.add(const LoginState.success());
-    } catch (e) {
+    } catch (e, st) {
+      logger.e('AUTH -> error: $e', e, st);
+      logger.i('AUTH -> state: error');
       _controller.add(LoginState.error(e.toString()));
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:logger/logger.dart';
+
 import 'firebase_options.dart';
 import 'login/login_view.dart';
 import 'login/firebase_auth_service.dart';
 import 'login/login_intent.dart';
 import 'login/auth_service.dart';
+
+class AuthLogFilter extends LogFilter {
+  @override
+  bool shouldLog(LogEvent event) {
+    return event.message.contains('AUTH');
+  }
+}
+
+final Logger logger = Logger(
+  filter: AuthLogFilter(),
+);
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
 
   # Google Sign-In
   google_sign_in: ^6.1.0
+  logger: ^1.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- install `logger` package
- configure a global `Logger` in `main.dart` filtering by the `AUTH` tag
- log all login states and errors in `LoginIntent`
- log Firebase auth success and errors in `FirebaseAuthService`

## Testing
- `flutter pub get` *(fails: flutter not installed)*
- `dart format -o none --set-exit-if-changed lib test` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68498204eba0832eb40c4f78382e18c5