### PR TITLE
Add log tag prefix

### DIFF
--- a/lib/app_logger.dart
+++ b/lib/app_logger.dart
@@ -1,18 +1,29 @@
 import 'package:logger/logger.dart';
 
-const String kAppTag = 'APP_TAG';
+/// Printer that prefixes every log line with [tag]. This allows filtering logs
+/// in tools like logcat.
+class TagPrinter extends LogPrinter {
+  TagPrinter(this.tag);
 
-final Logger logger = Logger(
-  // PrefixPrinter expects the prefix first, then the underlying printer
-  printer: PrefixPrinter(
-    kAppTag,
-    PrettyPrinter(
-      methodCount: 0,
-      errorMethodCount: 5,
-      lineLength: 120,
-      colors: true,
-      printEmojis: false,
-      printTime: false,
-    ),
-  ),
-);
+  final String tag;
+
+  final PrettyPrinter _delegate = PrettyPrinter(
+    methodCount: 0,
+    errorMethodCount: 5,
+    lineLength: 120,
+    colors: true,
+    printEmojis: false,
+    printTime: false,
+  );
+
+  @override
+  List<String> log(LogEvent event) {
+    return _delegate.log(event).map((line) => '$tag $line').toList();
+  }
+}
+
+/// Tag used for filtering logs. Search for this value in logcat.
+const String kAppTag = 'com.flutter.app';
+
+/// Global logger instance that prefixes all messages with [kAppTag].
+final Logger logger = Logger(printer: TagPrinter(kAppTag));


### PR DESCRIPTION
## Summary
- prefix all log output with a custom `com.flutter.app` tag

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849892e8c64832e95e35626baacf79e